### PR TITLE
收录 offer-helper（上岸 Offer 助手）— 中文求职 skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ cp -r claude-code-skills-zh/skills/* ~/.claude/skills/
 | [awesome-agent-skills](https://github.com/JackyST0/awesome-agent-skills) | 🇨🇳 精选 AI Agent Skills 列表，适配 Cursor / Claude Code / GitHub Copilot（463⭐）|
 | [wx-favorites-report](https://github.com/zhuyansen/wx-favorites-report) | 微信收藏可视化 Skill：从加密 DB 到交互式 HTML 报告的端到端管线（537⭐）|
 | [awesome-openclaw-skills-zh](https://github.com/clawdbot-ai/awesome-openclaw-skills-zh) | OpenClaw 中文官方技能库：按办公自动化、系统工具、开发运维等场景整理官方技能，适合中文用户快速发现与调用（4.0K⭐）|
+| [offer-helper](https://github.com/dominciyue/resume_skill) | 💼 中文求职助手：摄入简历/GitHub 仓库/文档建可持久化经历库，按 JD 生成 STAR 量化简历（严格防虚构），并做大厂式由浅及深的深挖面试 |
 
 ---
 


### PR DESCRIPTION
## 这是什么
offer-helper（上岸 Offer 助手）是一个面向求职者（学生 / 年轻职场人）的中文求职 skill，覆盖完整闭环：

1. **摄入建库**：把简历 / GitHub 仓库 / 其他文档整合成一份可持久化、可增量更新的经历库。
2. **定制简历**：分析 JD，用 STAR/XYZ 量化改写匹配经历，产出对标顶尖标准的 A4 简历 + 匹配度报告。
3. **大厂面试**：面试官锚定你简历里的技术点，由浅及深层层追问，探到能力边界。

## 差异化
- **严格防虚构**：每条都要溯源到真实材料，缺数字宁可留白也不编造；含 4 套端到端验收场景。
- **跨运行时诚实降级**：区分有/无文件系统环境，网页版如实告知无法持久化。
- 纯 Markdown + 1 个 HTML 模板，无网络代码，可几分钟审计。

## 链接
- 仓库：https://github.com/dominciyue/resume_skill

已按「🌏 中文专属」表格格式新增一行。感谢收录 🙏