### PR TITLE
Add Vexilo · Claude Code 工具书 to 相关资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ description: 技能的一句话描述
 - [awesome-claude-code-plugins](https://github.com/ccplugins/awesome-claude-code-plugins) — 697 ⭐
 - [cc-marketplace](https://github.com/ananddtyagi/cc-marketplace) — 677 ⭐
 - [claude-mem](https://github.com/thedotmack/claude-mem) — 72K ⭐
+- [Vexilo · Claude Code 工具书](https://vexilo.app/?lang=en) — 31 agents / 99 commands / 123 skills / 13 rules 的可视化工具书，按 5 步工作流组织，一键喂给 Claude。([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 - [claude-hud](https://github.com/jarrodwatts/claude-hud) — 21K ⭐
 - [agency-agents](https://github.com/msitarzewski/agency-agents) — 94.6K ⭐
 - [github/spec-kit](https://github.com/github/spec-kit) — 93.1K ⭐


### PR DESCRIPTION
## 新增 Vexilo · Claude Code 工具书 到"相关资源"列表

[Vexilo](https://vexilo.app/?lang=en) 是一个针对 Claude Code 的可视化工具书，包含 **31 agents / 99 commands / 123 skills / 13 rules**，按 5 步工作流（Research → Plan → Test-first → Security → Commit）组织。特色功能是一键 "Teach Claude this handbook"，30 秒把整本工具书喂给本地 Claude。

### 为什么适合这里
- 工具书形式，与其他 awesome list 同类资源互补
- 配套开源 repo: https://github.com/lilhawk7077/claude-code-resources (MIT)
- 双语（中英）支持，对中文开发者友好

### 检查清单
- [x] 项目活跃维护中 (v1.1.9)
- [x] 与 Claude Code 直接相关
- [x] 链接有效
- [x] 未与现有条目重复
- [x] 描述简洁明了