### PR TITLE
fix: 固定 playwright 依赖版本

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,6 @@
     "live-smoke-juejin": "node test_juejin_post.js --publish"
   },
   "dependencies": {
-    "playwright": "^1.40.0"
+    "playwright": "1.40.0"
   }
 }


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `scripts/package.json` pins `playwright` with a caret range (`^1.40.0`), allowing automatic minor/patch upgrades on install.

**Evidence**: Line 11 of `scripts/package.json`: `"playwright": "^1.40.0"` — a caret range, not an exact version.

**Fix**: Pin to the exact version already in use (`1.40.0`) so CI/local installs are reproducible.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:70a903016efdc5dd3f5871852e2ee8fa5e93ac3aab7dfbb4b3fb08f98bea16bf"}]}
nlpm-metadata-end -->