### PR TITLE
fix: 校验 draft_id 防止生成的 JS 脚本被注入

### DIFF
--- a/scripts/post_to_juejin.py
+++ b/scripts/post_to_juejin.py
@@ -4,6 +4,7 @@
 用法: python3.11 post_to_juejin.py "标题" "内容文件路径" --publish
 """
 import json
+import re
 import sys
 import os
 import subprocess
@@ -59,6 +60,9 @@ def create_draft_via_api(title, content, category_id="6809640410229036040"):
 
 def publish_via_browser(draft_id):
     """通过浏览器打开草稿并点击发布按钮"""
+    if not re.fullmatch(r"\d+", str(draft_id)):
+        raise ValueError(f"草稿 ID 格式异常，拒绝拼接执行: {draft_id!r}")
+
     # 构造 playwright 脚本
     js_code = f"""
 const {{ chromium }} = require('playwright');


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: In `scripts/post_to_juejin.py::publish_via_browser`, `draft_id` (from the Juejin API JSON response) is interpolated unescaped into an f-string that generates a `.js` file, which is then executed via `subprocess.run(['node', tmp_file])`.

**Evidence**: Reproduced locally — a `draft_id` value containing a single quote (e.g. `123'); require('child_process').execSync('touch /tmp/PWNED_MARKER'); ('`) breaks out of the `page.goto(...)` string literal in the generated JS, and the injected `require('child_process').execSync(...)` call executes when run with `node`, confirmed by the marker file being created.

**Fix**: Validate `draft_id` matches `^\d+$` before interpolation; raise `ValueError` and abort if it doesn't.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->