### PR TITLE
fix: 调试截图/结果文件写入仓库内 .tmp 目录而非系统临时目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 *.cookie
 .juejin_cookie
 
+# Scripts debug output
+/.tmp/
+
 # IDE
 .idea/
 .vscode/

--- a/scripts/post_to_juejin.js
+++ b/scripts/post_to_juejin.js
@@ -5,7 +5,8 @@ const path = require('path');
 
 const COOKIE_FILE = process.env.JUEJIN_COOKIE_FILE || path.join(os.homedir(), '.hermes', 'projects', 'claude-code-skills-zh', '.juejin_cookie');
 const COOKIE = process.env.JUEJIN_COOKIE || (fs.existsSync(COOKIE_FILE) ? fs.readFileSync(COOKIE_FILE, 'utf-8').trim() : '');
-const TEMP_DIR = os.tmpdir();
+const TEMP_DIR = path.join(__dirname, '..', '.tmp');
+fs.mkdirSync(TEMP_DIR, { recursive: true });
 const ERROR_SCREENSHOT = path.join(TEMP_DIR, 'juejin_error.png');
 const RESULT_SCREENSHOT = path.join(TEMP_DIR, 'juejin_result.png');
 const RESULT_JSON = path.join(TEMP_DIR, 'juejin_result.json');

--- a/scripts/test_juejin_post.js
+++ b/scripts/test_juejin_post.js
@@ -11,6 +11,8 @@ const path = require('path');
 
 const COOKIE_FILE = process.env.JUEJIN_COOKIE_FILE || path.join(os.homedir(), '.hermes', 'projects', 'claude-code-skills-zh', '.juejin_cookie');
 const COOKIE = process.env.JUEJIN_COOKIE || (fs.existsSync(COOKIE_FILE) ? fs.readFileSync(COOKIE_FILE, 'utf-8').trim() : '');
+const TEMP_DIR = path.join(__dirname, '..', '.tmp');
+fs.mkdirSync(TEMP_DIR, { recursive: true });
 
 if (!COOKIE) {
   console.error('❌ 缺少掘金 Cookie：请设置 JUEJIN_COOKIE 或写入 .juejin_cookie（不要提交 Cookie 到仓库）');
@@ -96,7 +98,7 @@ async function main() {
   await page.waitForTimeout(5000);
 
   // 截图看看页面状态
-  const draftScreenshot = path.join(os.tmpdir(), 'juejin_draft.png');
+  const draftScreenshot = path.join(TEMP_DIR, 'juejin_draft.png');
   await page.screenshot({ path: draftScreenshot, fullPage: false });
   console.log(`📸 页面截图已保存到 ${draftScreenshot}`);
 
@@ -108,7 +110,7 @@ async function main() {
     await page.waitForTimeout(5000);
 
     // 再截图
-    const publishedScreenshot = path.join(os.tmpdir(), 'juejin_published.png');
+    const publishedScreenshot = path.join(TEMP_DIR, 'juejin_published.png');
     await page.screenshot({ path: publishedScreenshot, fullPage: false });
     console.log(`📸 发布后截图已保存到 ${publishedScreenshot}`);
 


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `scripts/post_to_juejin.js` and `scripts/test_juejin_post.js` write debug screenshots and result JSON to `os.tmpdir()` (`/tmp`), a directory shared by all local users.

**Evidence**: Reproduced locally — `/tmp` has mode `1777` (world-writable) and files written there via `fs.writeFileSync`/`page.screenshot` default to mode `644` under the standard `umask 0022`, so any other local user on the same machine can read the draft/publish screenshots.

**Fix**: Write to a new gitignored `.tmp/` directory under the repo root instead of `os.tmpdir()`, created via `fs.mkdirSync(TEMP_DIR, { recursive: true })`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-temp-file-write","fingerprint":"sha256:c949f71c4d1fa09e8c29690639cfb7dab79feca91ef138b5b9ad7628b062a60c"},{"rule_id":"SEC-temp-file-write","fingerprint":"sha256:fa5e9803f2ff3c1a834b85059c9727fc819a7d7316103668c27e40df2e83e529"}]}
nlpm-metadata-end -->