### PR TITLE
新增 hello-boss：冷启动获客流水线

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ cp -r claude-code-skills-zh/skills/* ~/.claude/skills/
 | [luopan](https://github.com/zhangxiaoqiang1991/luopan) | 中文行业与公司研究路由 Skill：通过信源分级和对抗验证分析产业链权力、利润分布与公司质量，适合投资或求职研究，不替代投资建议（376⭐）|
 | [qlik-oss/agentic-skills](https://github.com/qlik-oss/agentic-skills) | Qlik 官方 Agentic Skills Hub：提供 Qlik Cloud AI readiness / MCP 优化 Skill、官方与社区插件分层、`npx skills add` 与 Claude Code plugin 安装路径（8⭐）|
 | [niubiskill](https://github.com/nathanskill/niubiskill) | 中文变现决策 Skill：打断无收入验证的瞎忙，找到离真实收钱最近的一步，二选一（引流 / 成交），停掉一件分散精力的事并给出 7 天证据测试，支持 `npx skills add nathanskill/niubiskill` 安装；不承诺收益，涉及受监管活动时需先核验权限（204⭐）|
+| [babyGao/agent-pilot-skills](https://github.com/babyGao/agent-pilot-skills/tree/main/skills/hello-boss) | hello-boss 冷启动获客流水线：五条穷举路径把“谁能买我的东西”挖穷、四信号收敛从公开工商数据锁定经营主体和邮箱、四段式开发信，产出三份验收物（1⭐） |
 
 ---
 


### PR DESCRIPTION
### 是什么

[hello-boss](https://github.com/babyGao/agent-pilot-skills/tree/main/skills/hello-boss) —— 让 agent 去当销售。四步走完，交三份验收物（需求调研报告、合作对象清单、开发信模板），然后就停。

### 解决什么问题

冷启动获客真正难的是两头，而现成工具几乎只管中间。问一个做物流的"客户是谁"，答案永远是"货运同行"——因为没人有办法系统地穷举"谁能买我这套东西"。

skill 先把身份换成**作业**（不是"我是物流公司"，而是"我把有体积有重量的东西从 A 搬到 B，并承担时效和破损风险"），再走五条互相独立的穷举路径：投入产出表的直接消耗系数、逐个过 20 个行业门类防漏、同一作业跨行业迁移、把招聘 JD 当需求信号读、从"我解除什么约束"反推。典型效果是候选行业从 4 个变成 30 个以上，且排序有实测数字撑着。

第二头是主体判定：四条互相独立的信号（品牌搜企业名、商标持有人、地址吻合、店铺层级）收敛成三档置信度，弱档一律不猜，改走兜底通道问一句。

### 中文场景适配

`references/` 里带了 GB/T 4754-2017 的 20 个行业门类清单、天眼查／爱企查／国家企业信用信息公示系统各自的配额和字段差异、以及平台风控的三级台阶——并列了 NAICS／Companies House／SEC EDGAR 的对应写法，方法不变只换数据源。

所有数字来自 2026 年 9 月一轮 58 家的真实投放，**包括做错的部分**。MIT，无付费依赖。