### PR TITLE
收录 yylo-skills — 编码代理任务管理技能包（🤖 AI Agent）

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ cp -r claude-code-skills-zh/skills/* ~/.claude/skills/
 | [ccteam](https://github.com/firstintent/ccteam) | 自托管 Claude Code / Codex 多 Agent 团队控制台：通过 Telegram、飞书或 Web 远程派单、收集结果并限制层级、并发和预算；默认监听 `0.0.0.0:7331` 且无 TLS，仅建议用于可信局域网或改为绑定本机（500⭐）|
 | [ruflo](https://github.com/ruvnet/ruflo) | Agent 元编排框架：为 Claude Code / Codex 提供多智能体集群、任务分解与共享记忆，30 个 SKILL.md 可按需安装，MIT 许可（71.9K⭐）|
 | [ego-lite](https://github.com/citrolabs/ego-lite) | 面向 AI Agent 的共享浏览器：Agent 在独立 Space 里运行多个浏览器任务，复用用户真实登录态和标签页，减少 token 消耗；内置 `ego-browser` Skill，目前仅支持 macOS，Windows / Linux 在路线图（15.6K⭐）|
+| [yylo-skills](https://github.com/yylo-dev/yylo-skills) | YYLO 官方编码代理技能包：7 个 SKILL.md 覆盖看板任务管理、任务规划、项目理解、wiki 知识与经验证交付循环，支持 `npx skills add yylo-dev/yylo-skills` 安装到 Claude Code / Codex / Pi（0⭐）|
 
 ### 💰 金融/商业
 


### PR DESCRIPTION
## 变更内容

- [x] 新增资源条目
- [ ] 更新已有描述 / 分类 / 星标
- [ ] 修复断链或错误信息
- [ ] 更新原创 skill
- [ ] 其他维护

## 资源信息

项目链接：https://github.com/yylo-dev/yylo-skills

推荐分类：🤖 AI Agent

一句话说明：YYLO 官方编码代理技能包——7 个 SKILL.md 覆盖看板任务管理、任务规划、项目理解、wiki 知识与经验证交付循环，`npx skills add yylo-dev/yylo-skills` 一键安装到 Claude Code / Codex / Pi。

## 为什么值得收录

- 标准 Skill 结构：`skills/<slug>/SKILL.md` 共 7 个（ledger-tasks / wiki / workflow / artifact / understand-project / plan-ledger-tasks / ralph-loop），MIT 开源。
- 安装路径清晰：`npx skills add yylo-dev/yylo-skills`（支持 `-a claude-code -a codex -a pi`，slug 统一以 `-yylo` 结尾便于选择）。
- 面向高频场景：编码代理的看板任务状态、规划、项目理解、知识沉淀与经验证的交付循环；母项目 YYLO CLI（58★）与 YYLO Ledger 每日活跃维护，npm 包 `@yylo/cli`、`@yylo/ledger` 已发布。
- 仓库较新（2026-09 创建，当前 0⭐），作者组织 yylo-dev 可信、安装路径清晰、场景价值强，符合维护手册对新增仓库的收录条件；如后续星标变化，维护脚本会自动同步。

## 自检清单

- [x] 链接可以打开，不是 404 或私有仓库
- [x] 内容与 Claude Code / Codex / Agent Skills / Plugins / MCP / AI 编程工作流直接相关
- [x] README 描述简洁，没有夸张营销词
- [x] 如果修改了 README，已同步或确认需要同步 `docs/index.html`（本 PR 只在 AI Agent 表末新增一行，星标与站点由维护脚本自动同步）
- [x] 没有删除无关内容

## 说明（披露）

- 提交者属于 YYLO 团队（self-submission），本 PR 由 AI agent 辅助准备并按仓库模板与《项目维护手册》收录标准自检；如描述措辞、分类或位置需要调整，欢迎直接修改或告知，我可以跟进调整或撤回。
